### PR TITLE
Add local preview setup with HTML templates and build scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Squarespace local development
+SQUARESPACE_SITE_URL=https://your-site.squarespace.com
+SQUARESPACE_DEV_PORT=9000
+SQUARESPACE_DEV_AUTH=0
+SQUARESPACE_DEV_VERBOSE=0
+
+# Local visual preview
+PREVIEW_PORT=4321

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 sftp-config.json
+node_modules/
+.preview/
+.env
+.env.local

--- a/blocks/site-navigation.block
+++ b/blocks/site-navigation.block
@@ -1,23 +1,34 @@
 <nav class="site-navigation">
   <ul class="site-navigation-list">
     {.repeated section items}
+      <li class="site-navigation-item {.section active} active-link{.end}{.if folderActive} active-link active-folder{.end}">
+        {.folder?}
+          <a>{collection.navigationTitle}</a>
+          <ul class="site-sub-navigation-list">
+            {.repeated section items}
+              {.collection?}
+                <li class="site-sub-navigation-item {.section active} active-link{.end}">
+                  <a href="{collection.fullUrl}">{collection.navigationTitle}</a>
+                </li>
+              {.end}
 
-      <li class="site-navigation-item {.section active} active-link{.end}">
+              {.section externalLink}
+                <li class="site-sub-navigation-item external-link">
+                  <a href="{url}"{.section newWindow} target="_blank"{.end}>{title}</a>
+                </li>
+              {.end}
+            {.end}
+          </ul>
+        {.or}
+          {.section collection}
+            <a href="{fullUrl}">{navigationTitle}</a>
+          {.end}
 
-        <!-- collection link -->
-        {.section collection}
-          <a href="{fullUrl}">{navigationTitle}</a>
+          {.section externalLink}
+            <a href="{url}"{.section newWindow} target="_blank"{.end}>{title}</a>
+          {.end}
         {.end}
-
-        <!-- external link -->
-        {.section externalLink}
-          <a href="{url}"{.section newWindow} target="_blank"{.end}>
-            {title}
-          </a>
-        {.end}
-
       </li>
-
     {.end}
   </ul>
 </nav>

--- a/collections/blog.item
+++ b/collections/blog.item
@@ -19,24 +19,36 @@
     </p>
 
     <!--MAIN CONTENT-->
-    {body}
+    <div class="post-body">
+      {body}
+    </div>
 
     <!--BLOG INJECTION-->
     {postItemInjectCode}
 
     <!--CATEGORIES-->
-    {.repeated section categories}
-      <a class="category" href="{collection.fullUrl}?category={@|url-encode}">{@}</a>{.alternates with},
+    {.section categories}
+      <div class="post-taxonomy">
+        {.repeated section categories}
+          <a class="category" href="{collection.fullUrl}?category={@|url-encode}">{@}</a>
+        {.end}
+      </div>
     {.end}
 
     <!--TAGS-->
-    {.repeated section tags}
-      <a class="tag" href="{collection.fullUrl}?tag={@|url-encode}">{@}</a>{.alternates with},
+    {.section tags}
+      <div class="post-taxonomy">
+        {.repeated section tags}
+          <a class="tag" href="{collection.fullUrl}?tag={@|url-encode}">{@}</a>
+        {.end}
+      </div>
     {.end}
 
     <!--SHARE AND LIKE-->
-    {@|like-button}
-    {@|social-button}
+    <div class="post-actions">
+      {@|like-button}
+      {@|social-button}
+    </div>
 
 
     <!--LOCATION-->

--- a/collections/blog.list
+++ b/collections/blog.list
@@ -29,12 +29,20 @@
         <a href="{fullUrl}">{title}</a>
       {.end}
     </h1>
+    <p class="meta">
+      <a href="{fullUrl}" class="permalink"><time datetime="{addedOn|date %F}">{addedOn|date %B %d, %Y}</time></a>
+      <span class="byline"> by <a href="{collection.fullUrl}?author={author.id}">{author.displayName}</a></span>
+    </p>
     <!-- excerpt or body -->
     {.if excerpt}
-      {excerpt}
+      <div class="excerpt">
+        {excerpt}
+      </div>
       <a class="link" href="{fullUrl}">Read More</a>
     {.or}
-      {body}
+      <div class="post-body">
+        {body}
+      </div>
     {.end}
   </article>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,217 @@
+{
+  "name": "simply-taylor",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "less": "^4.6.4"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/errno": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
+      "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "prr": "~1.0.1"
+      },
+      "bin": {
+        "errno": "cli.js"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/less": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.6.4.tgz",
+      "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "copy-anything": "^3.0.5",
+        "parse-node-version": "^1.0.1"
+      },
+      "bin": {
+        "lessc": "bin/lessc"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
+        "needle": "^3.1.0",
+        "source-map": "~0.6.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/needle": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/parse-node-version": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "scripts": {
+    "doctor": "node scripts/doctor.js",
+    "dev": "npm run sqsp:dev",
+    "dev:auth": "npm run sqsp:dev:auth",
+    "dev:verbose": "npm run sqsp:dev:verbose",
+    "start": "npm run preview",
+    "build": "npm run preview:build",
+    "sqsp:dev": "node scripts/squarespace-dev.js",
+    "sqsp:dev:auth": "node scripts/squarespace-dev.js --auth",
+    "sqsp:dev:verbose": "node scripts/squarespace-dev.js --verbose",
+    "preview": "node scripts/preview.js",
+    "preview:build": "node scripts/preview.js --once"
+  },
+  "dependencies": {
+    "less": "^4.6.4"
+  }
+}

--- a/preview/blog.html
+++ b/preview/blog.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simply Taylor Journal Preview</title>
+    <link rel="stylesheet" href="/site.css">
+  </head>
+  <body class="collection-type-blog view-list">
+    <div class="site-container">
+      <header class="site-header">
+        <nav class="site-navigation">
+          <ul class="site-navigation-list">
+            <li class="site-navigation-item"><a href="/">Home</a></li>
+            <li class="site-navigation-item active-link"><a href="/blog.html">Journal</a></li>
+            <li class="site-navigation-item"><a href="/post.html">Editorial</a></li>
+          </ul>
+        </nav>
+
+        <h1 class="site-title-heading">
+          <a href="/" class="site-title-link">Simply Taylor</a>
+        </h1>
+      </header>
+
+      <main class="content-container" role="main">
+        <p class="filtered-by">Filtered by Category: Spring Edit</p>
+
+        <article class="blog-list-item">
+          <a href="/post.html" class="main-image">
+            <img alt="Fashion sketch collage" src="https://images.unsplash.com/photo-1529139574466-a303027c1d8b?auto=format&fit=crop&w=1200&q=80">
+          </a>
+          <h1 class="title"><a href="/post.html">Cafe Cream Tailoring</a></h1>
+          <p class="meta">
+            <a href="/post.html" class="permalink"><time datetime="2026-03-20">March 20, 2026</time></a>
+            <span class="byline"> by Taylor</span>
+          </p>
+          <div class="excerpt">
+            <p>
+              A small run of satin bows, camel checks, and lipstick-red trims designed to feel
+              collected from an old Left Bank boutique and restyled with sharper editorial balance.
+            </p>
+          </div>
+          <a class="link" href="/post.html">Read More</a>
+        </article>
+
+        <article class="blog-list-item">
+          <a href="/post.html" class="main-image">
+            <img alt="Vintage boutique interior" src="https://images.unsplash.com/photo-1483985988355-763728e1935b?auto=format&fit=crop&w=1200&q=80">
+          </a>
+          <h1 class="title"><a href="/post.html">Powder Room Objects</a></h1>
+          <p class="meta">
+            <a href="/post.html" class="permalink"><time datetime="2026-03-18">March 18, 2026</time></a>
+            <span class="byline"> by Taylor</span>
+          </p>
+          <div class="excerpt">
+            <p>
+              Silk pouches, lacquer trays, and gilded keepsakes merchandised like story props
+              rather than stock units, so the catalog reads as an atmosphere instead of a grid.
+            </p>
+          </div>
+          <a class="link" href="/post.html">Read More</a>
+        </article>
+
+        <article class="blog-list-item">
+          <a href="/post.html" class="main-image">
+            <img alt="Paris street scene" src="https://images.unsplash.com/photo-1499856871958-5b9627545d1a?auto=format&fit=crop&w=1200&q=80">
+          </a>
+          <h1 class="title"><a href="/post.html">Blue Hour on Rue Cler</a></h1>
+          <p class="meta">
+            <a href="/post.html" class="permalink"><time datetime="2026-03-14">March 14, 2026</time></a>
+            <span class="byline"> by Taylor</span>
+          </p>
+          <div class="excerpt">
+            <p>
+              Clashing butter yellow, powder blue, and rose wash backgrounds turn each story block
+              into a poster panel, which is closer to the intended visual rhythm than a neutral blog feed.
+            </p>
+          </div>
+          <a class="link" href="/post.html">Read More</a>
+        </article>
+      </main>
+
+      <footer class="site-footer">
+        Local preview only. Journal cards approximate the Squarespace list view.
+      </footer>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/animejs/dist/bundles/anime.umd.min.js"></script>
+    <script src="/site.js"></script>
+  </body>
+</html>

--- a/preview/index.html
+++ b/preview/index.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simply Taylor Preview</title>
+    <link rel="stylesheet" href="/site.css">
+  </head>
+  <body class="homepage">
+    <div class="site-container">
+      <header class="site-header">
+        <nav class="site-navigation">
+          <ul class="site-navigation-list">
+            <li class="site-navigation-item active-link"><a href="/">Home</a></li>
+            <li class="site-navigation-item"><a href="/blog.html">Journal</a></li>
+            <li class="site-navigation-item"><a href="/post.html">Editorial</a></li>
+          </ul>
+        </nav>
+
+        <h1 class="site-title-heading">
+          <a href="/" class="site-title-link">Simply Taylor</a>
+        </h1>
+      </header>
+
+      <main class="content-container" role="main">
+        <section>
+          <h1>Parisienne catalogue energy with a softer bite.</h1>
+          <p>
+            This local preview mirrors the base template styling so you can refine layout,
+            color, and typography without waiting on a Squarespace upload cycle.
+          </p>
+          <p>
+            Use the Journal and Editorial links above to inspect the blog list and single-post
+            views with the current design system applied.
+          </p>
+          <a class="link" href="/blog.html">Open Journal View</a>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        Local preview only. Squarespace JSON-T is not rendered here.
+      </footer>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/animejs/dist/bundles/anime.umd.min.js"></script>
+    <script src="/site.js"></script>
+  </body>
+</html>
+

--- a/preview/post.html
+++ b/preview/post.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simply Taylor Editorial Preview</title>
+    <link rel="stylesheet" href="/site.css">
+  </head>
+  <body class="collection-type-blog view-item">
+    <div class="site-container">
+      <header class="site-header">
+        <nav class="site-navigation">
+          <ul class="site-navigation-list">
+            <li class="site-navigation-item"><a href="/">Home</a></li>
+            <li class="site-navigation-item"><a href="/blog.html">Journal</a></li>
+            <li class="site-navigation-item active-link"><a href="/post.html">Editorial</a></li>
+          </ul>
+        </nav>
+
+        <h1 class="site-title-heading">
+          <a href="/" class="site-title-link">Simply Taylor</a>
+        </h1>
+      </header>
+
+      <main class="content-container" role="main">
+        <article id="post-preview">
+          <h1 class="title">The Keepsake Dressing Story</h1>
+          <p class="meta">
+            <a href="/post.html" class="permalink"><time datetime="2026-03-20">March 20, 2026</time></a>
+            by <a href="/blog.html">Taylor</a>
+          </p>
+
+          <div class="post-body">
+            <p>
+              This page approximates the single-post composition so you can refine spacing,
+              typography, buttons, and taxonomy treatment locally before pushing the template into Squarespace.
+            </p>
+            <blockquote>
+              Style the catalog like a remembered room, not a spreadsheet.
+            </blockquote>
+            <p>
+              The current direction leans into rose paper, powder-blue contrast, and typewriter labels
+              against a bolder retro display face to keep the experience feminine without losing edge.
+            </p>
+          </div>
+
+          <div class="post-taxonomy">
+            <a class="category" href="/blog.html">Spring Edit</a>
+            <a class="category" href="/blog.html">Objects</a>
+          </div>
+
+          <div class="post-taxonomy">
+            <a class="tag" href="/blog.html">Parisian</a>
+            <a class="tag" href="/blog.html">Vintage</a>
+            <a class="tag" href="/blog.html">Catalog</a>
+          </div>
+
+          <div class="post-actions">
+            <a class="link" href="/blog.html">Back to Journal</a>
+          </div>
+        </article>
+      </main>
+
+      <footer class="site-footer">
+        Local preview only. Editorial layout approximates the Squarespace item view.
+      </footer>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/animejs/dist/bundles/anime.umd.min.js"></script>
+    <script src="/site.js"></script>
+  </body>
+</html>

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,51 @@
+### Local Preview
+
+This repo now includes a small local preview harness for the template stylesheet.
+
+- Copy `.env.example` to `.env` or `.env.local` to configure local settings.
+- `npm run doctor` checks local prerequisites and environment variables.
+- `npm start` starts the local visual preview server.
+- `npm run preview` compiles `styles/base.less` plus `styles/reset.css`, watches for style changes, and serves preview pages at `http://localhost:4321`.
+- `npm run build` runs the local preview stylesheet build.
+- `npm run preview:build` runs a one-off stylesheet compile into `.preview/site.css`.
+- Preview routes:
+  - `/` homepage shell
+  - `/blog.html` blog list approximation
+  - `/post.html` blog item approximation
+
+This does not execute Squarespace JSON-T locally. It is intended for fast visual iteration on the base design system before uploading the template to Squarespace.
+
+### Squarespace Local Development
+
+For the supported local developer workflow, use Squarespace's Local Development Server against a real Developer Mode site.
+
+- Install the official server first by following the Squarespace docs: https://developers.squarespace.com/local-development
+- Run `npm run doctor` if the local environment is not behaving as expected.
+- Preferred setup: copy `.env.example` to `.env` and set `SQUARESPACE_SITE_URL`.
+- Shell environment variables still work and override `.env` values:
+  - PowerShell: `$env:SQUARESPACE_SITE_URL="https://your-site.squarespace.com"`
+- Start the official server from this repo:
+  - `npm run dev`
+  - `npm run sqsp:dev`
+- Optional variants:
+  - `npm run dev:auth`
+  - `npm run dev:verbose`
+  - `npm run sqsp:dev:auth`
+  - `npm run sqsp:dev:verbose`
+- Optional port override:
+  - `.env`: `SQUARESPACE_DEV_PORT=9000`
+  - PowerShell: `$env:SQUARESPACE_DEV_PORT="9000"`
+
+Supported environment variables:
+
+- `SQUARESPACE_SITE_URL`: required for Squarespace-backed local development
+- `SQUARESPACE_DEV_PORT`: port used by the Squarespace local development server
+- `SQUARESPACE_DEV_AUTH`: set to `1` to add `--auth`
+- `SQUARESPACE_DEV_VERBOSE`: set to `1` to add `--verbose`
+- `PREVIEW_PORT`: port used by `npm start`
+
+The repo script lives at `scripts/squarespace-dev.js` and forwards the current template directory to `squarespace-server`.
+
 Base Template
 ------------------------------
 
@@ -51,3 +99,4 @@ See the [Template Configuration documentation](https://developers.squarespace.co
 ### Further Reading
 
 For further reading please consult the [Squarespace Template Overview](https://developers.squarespace.com/template-overview/) and other documentation on the Squarespace developers website.
+

--- a/scripts/doctor.js
+++ b/scripts/doctor.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { loadEnv } = require('./load-env');
+
+const rootDir = path.resolve(__dirname, '..');
+loadEnv(rootDir);
+
+const siteUrl = process.env.SQUARESPACE_SITE_URL;
+
+function check(label, ok, detail) {
+  const status = ok ? 'OK' : 'FAIL';
+  console.log(`[${status}] ${label}`);
+  if (detail) {
+    console.log(`       ${detail}`);
+  }
+  return ok;
+}
+
+function exists(relativePath) {
+  return fs.existsSync(path.join(rootDir, relativePath));
+}
+
+function checkSquarespaceServer() {
+  const command = process.platform === 'win32' ? 'squarespace-server.cmd' : 'squarespace-server';
+  const probe = spawnSync(command, ['--help'], {
+    cwd: rootDir,
+    stdio: 'pipe',
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
+
+  if (!probe.error) {
+    return {
+      ok: true,
+      detail: 'squarespace-server is available in the current shell.',
+    };
+  }
+
+  return {
+    ok: false,
+    detail: 'Install the Squarespace local development server and ensure `squarespace-server` is on PATH.',
+  };
+}
+
+function main() {
+  let ok = true;
+
+  ok = check('Node.js detected', Boolean(process.version), `Using ${process.version}`) && ok;
+  ok = check('package.json present', exists('package.json'), 'Required for npm script entrypoints.') && ok;
+  ok = check('Preview script present', exists('scripts/preview.js'), 'Used by `npm start` and `npm run build`.') && ok;
+  ok = check('Squarespace dev wrapper present', exists('scripts/squarespace-dev.js'), 'Used by `npm run dev`.') && ok;
+  ok = check(
+    '.env example present',
+    exists('.env.example'),
+    'Copy this file to `.env` or `.env.local` to configure local settings.'
+  ) && ok;
+  ok = check(
+    'SQUARESPACE_SITE_URL configured',
+    Boolean(siteUrl),
+    siteUrl
+      ? `Current value: ${siteUrl}`
+      : 'Set it in PowerShell, for example: $env:SQUARESPACE_SITE_URL="https://your-site.squarespace.com"'
+  ) && ok;
+
+  const sqspServer = checkSquarespaceServer();
+  ok = check('Squarespace local dev server callable', sqspServer.ok, sqspServer.detail) && ok;
+
+  console.log('');
+  if (ok) {
+    console.log('Environment looks ready.');
+    console.log('Next steps:');
+    console.log('- npm start');
+    console.log('- npm run dev');
+    return;
+  }
+
+  console.log('Environment is not fully ready.');
+  console.log('Next steps:');
+  if (!siteUrl) {
+    console.log('- Set SQUARESPACE_SITE_URL in your shell.');
+  }
+  if (!sqspServer.ok) {
+    console.log('- Install the official Squarespace local development server.');
+    console.log('- Docs: https://developers.squarespace.com/local-development');
+  }
+  console.log('- Use `npm start` for the local visual preview in the meantime.');
+  process.exitCode = 1;
+}
+
+main();

--- a/scripts/load-env.js
+++ b/scripts/load-env.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseEnv(content) {
+  const lines = content.split(/\r?\n/);
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex === -1) continue;
+
+    const key = line.slice(0, separatorIndex).trim();
+    let value = line.slice(separatorIndex + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function loadEnv(rootDir) {
+  const candidates = ['.env', '.env.local'];
+
+  for (const relativePath of candidates) {
+    const absolutePath = path.join(rootDir, relativePath);
+    if (!fs.existsSync(absolutePath)) continue;
+    parseEnv(fs.readFileSync(absolutePath, 'utf8'));
+  }
+}
+
+module.exports = { loadEnv };

--- a/scripts/preview.js
+++ b/scripts/preview.js
@@ -1,0 +1,132 @@
+const fs = require('fs');
+const fsp = require('fs/promises');
+const http = require('http');
+const path = require('path');
+const less = require('less');
+const { loadEnv } = require('./load-env');
+
+const rootDir = path.resolve(__dirname, '..');
+loadEnv(rootDir);
+
+const stylesDir = path.join(rootDir, 'styles');
+const previewSourceDir = path.join(rootDir, 'preview');
+const previewBuildDir = path.join(rootDir, '.preview');
+const port = Number(process.env.PREVIEW_PORT || process.env.PORT || 4321);
+const runOnce = process.argv.includes('--once');
+
+async function ensureDir(dir) {
+  await fsp.mkdir(dir, { recursive: true });
+}
+
+async function compileStyles() {
+  const resetPath = path.join(stylesDir, 'reset.css');
+  const basePath = path.join(stylesDir, 'base.less');
+  const resetCss = await fsp.readFile(resetPath, 'utf8');
+  const sourceLess = await fsp.readFile(basePath, 'utf8');
+  const fontImports = Array.from(
+    sourceLess.matchAll(/^\s*@import\s+url\((.+?)\);\s*$/gm),
+    (match) => `@import url(${match[1]});`
+  );
+  const baseLess = sourceLess
+    .replace(/^\s*@import\s+url\(.+?\);\s*$/gm, '')
+    .replace(/^\s*@import\s+['"]sqs-grid-breaker['"];\s*$/gm, '');
+  const compiled = await less.render(baseLess, {
+    filename: basePath,
+    paths: [stylesDir],
+  });
+
+  await ensureDir(previewBuildDir);
+  await fsp.writeFile(
+    path.join(previewBuildDir, 'site.css'),
+    `${fontImports.join('\n')}\n${resetCss}\n\n${compiled.css}`,
+    'utf8'
+  );
+}
+
+async function buildPreview() {
+  await compileStyles();
+}
+
+function contentType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.css') return 'text/css; charset=utf-8';
+  if (ext === '.js') return 'application/javascript; charset=utf-8';
+  if (ext === '.html') return 'text/html; charset=utf-8';
+  if (ext === '.json') return 'application/json; charset=utf-8';
+  if (ext === '.svg') return 'image/svg+xml';
+  if (ext === '.png') return 'image/png';
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  return 'text/plain; charset=utf-8';
+}
+
+async function readServedFile(urlPath) {
+  if (urlPath === '/site.css') {
+    return path.join(previewBuildDir, 'site.css');
+  }
+
+  if (urlPath === '/site.js') {
+    return path.join(rootDir, 'scripts', 'site.js');
+  }
+
+  const safePath = urlPath === '/' ? '/index.html' : urlPath;
+  const normalized = path.normalize(safePath).replace(/^(\.\.[/\\])+/, '');
+  return path.join(previewSourceDir, normalized);
+}
+
+function startServer() {
+  const server = http.createServer(async (req, res) => {
+    try {
+      const target = await readServedFile(req.url || '/');
+      const stat = await fsp.stat(target);
+      const filePath = stat.isDirectory() ? path.join(target, 'index.html') : target;
+      const body = await fsp.readFile(filePath);
+      res.writeHead(200, { 'Content-Type': contentType(filePath) });
+      res.end(body);
+    } catch (error) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Preview file not found.');
+    }
+  });
+
+  server.listen(port, () => {
+    console.log(`Preview running at http://localhost:${port}`);
+    console.log('Routes: /, /blog.html, /post.html');
+  });
+}
+
+function watchStyles() {
+  let rebuildTimer = null;
+  const rebuild = async () => {
+    try {
+      await buildPreview();
+      console.log('Rebuilt preview CSS');
+    } catch (error) {
+      console.error('Preview rebuild failed');
+      console.error(error.message);
+    }
+  };
+
+  fs.watch(stylesDir, { recursive: true }, (_eventType, filename) => {
+    if (!filename || !/\.(less|css)$/i.test(filename)) return;
+    clearTimeout(rebuildTimer);
+    rebuildTimer = setTimeout(rebuild, 60);
+  });
+}
+
+async function main() {
+  try {
+    await buildPreview();
+    console.log('Built preview CSS');
+
+    if (runOnce) return;
+
+    watchStyles();
+    startServer();
+  } catch (error) {
+    console.error('Preview setup failed');
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/scripts/site.js
+++ b/scripts/site.js
@@ -1,26 +1,128 @@
-
 /**
- * This script wrapped in a Immediately-Invoked Function Expression (IIFE) to
- * prevent variables from leaking onto the global scope. For more information
- * on IIFE visit the link below.
- * @see http://en.wikipedia.org/wiki/Immediately-invoked_function_expression
+ * Site interactions and responsive image loading.
  */
 
 (function() {
   'use strict';
 
-  // Load all images via Squarespace's Responsive ImageLoader
   function loadAllImages() {
-    var images = document.querySelectorAll('img[data-src]' );
+    var images = document.querySelectorAll('img[data-src]');
     for (var i = 0; i < images.length; i++) {
-      ImageLoader.load(images[i], {load: true});
+      ImageLoader.load(images[i], { load: true });
     }
   }
 
-  // The event subscription that loads images when the page is ready
-  document.addEventListener('DOMContentLoaded', loadAllImages);
+  function getAnime() {
+    if (window.anime && typeof window.anime.animate === 'function') {
+      return window.anime;
+    }
 
-  // The event subscription that reloads images on resize
+    return null;
+  }
+
+  function animateBlogList(anime) {
+    var cards = document.querySelectorAll('.blog-list-item');
+    if (!cards.length) return;
+
+    anime.animate(cards, {
+      opacity: [0, 1],
+      translateY: [56, 0],
+      rotate: [1.5, 0],
+      delay: anime.stagger(120, { start: 120 }),
+      duration: 1100,
+      ease: 'out(3)'
+    });
+
+    for (var i = 0; i < cards.length; i++) {
+      bindCardHover(cards[i], anime);
+    }
+  }
+
+  function bindCardHover(card, anime) {
+    var activeAnimation = null;
+
+    function play(state) {
+      if (activeAnimation && typeof activeAnimation.pause === 'function') {
+        activeAnimation.pause();
+      }
+
+      activeAnimation = anime.animate(card, {
+        translateY: state === 'enter' ? -10 : 0,
+        rotate: state === 'enter' ? -0.4 : 0,
+        scale: state === 'enter' ? 1.01 : 1,
+        duration: state === 'enter' ? 420 : 520,
+        ease: state === 'enter' ? 'out(4)' : 'out(2)'
+      });
+    }
+
+    card.addEventListener('mouseenter', function() {
+      play('enter');
+    });
+
+    card.addEventListener('mouseleave', function() {
+      play('leave');
+    });
+  }
+
+  function animateBlogItem(anime) {
+    var article = document.querySelector('.collection-type-blog.view-item article');
+    if (!article) return;
+
+    var children = article.children;
+    anime.animate(children, {
+      opacity: [0, 1],
+      translateY: [34, 0],
+      delay: anime.stagger(90, { start: 120 }),
+      duration: 900,
+      ease: 'out(3)'
+    });
+  }
+
+  function animateButtons(anime) {
+    var buttons = document.querySelectorAll('.link, .category, .tag, .blog-list-pagination a, .blog-item-pagination a');
+
+    for (var i = 0; i < buttons.length; i++) {
+      bindButtonHover(buttons[i], anime);
+    }
+  }
+
+  function bindButtonHover(button, anime) {
+    var activeAnimation = null;
+
+    function play(scale, duration) {
+      if (activeAnimation && typeof activeAnimation.pause === 'function') {
+        activeAnimation.pause();
+      }
+
+      activeAnimation = anime.animate(button, {
+        scale: scale,
+        duration: duration,
+        ease: 'out(4)'
+      });
+    }
+
+    button.addEventListener('mouseenter', function() {
+      play(1.03, 280);
+    });
+
+    button.addEventListener('mouseleave', function() {
+      play(1, 360);
+    });
+  }
+
+  function initAnimations() {
+    var anime = getAnime();
+    if (!anime) return;
+
+    animateBlogList(anime);
+    animateBlogItem(anime);
+    animateButtons(anime);
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    loadAllImages();
+    initAnimations();
+  });
+
   window.addEventListener('resize', loadAllImages);
-
 }());

--- a/scripts/squarespace-dev.js
+++ b/scripts/squarespace-dev.js
@@ -1,0 +1,90 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const { loadEnv } = require('./load-env');
+
+const rootDir = path.resolve(__dirname, '..');
+loadEnv(rootDir);
+
+const siteUrl = process.env.SQUARESPACE_SITE_URL;
+const port = process.env.SQUARESPACE_DEV_PORT || '9000';
+const args = process.argv.slice(2);
+const useAuth = args.includes('--auth') || process.env.SQUARESPACE_DEV_AUTH === '1';
+const useVerbose = args.includes('--verbose') || process.env.SQUARESPACE_DEV_VERBOSE === '1';
+
+if (!siteUrl) {
+  console.error('Missing SQUARESPACE_SITE_URL');
+  console.error('Example: $env:SQUARESPACE_SITE_URL="https://your-site.squarespace.com"; npm.cmd run sqsp:dev');
+  process.exit(1);
+}
+
+const serverArgs = [siteUrl, '--directory', rootDir, '--port', port];
+
+if (useAuth) {
+  serverArgs.push('--auth');
+}
+
+if (useVerbose) {
+  serverArgs.push('--verbose');
+}
+
+function quoteWindowsArg(value) {
+  return `"${String(value).replace(/"/g, '\\"')}"`;
+}
+
+let child;
+
+try {
+  child = process.platform === 'win32'
+    ? spawn(
+        'cmd.exe',
+        ['/d', '/s', '/c', ['squarespace-server.cmd'].concat(serverArgs).map(quoteWindowsArg).join(' ')],
+        { cwd: rootDir, stdio: ['inherit', 'pipe', 'pipe'] }
+      )
+    : spawn('squarespace-server', serverArgs, {
+        cwd: rootDir,
+        stdio: ['inherit', 'pipe', 'pipe'],
+      });
+} catch (error) {
+  console.error('Failed to start the Squarespace local development server.');
+  console.error(error.message);
+  console.error('Install the Squarespace local development server first, then rerun this command.');
+  console.error('Docs: https://developers.squarespace.com/local-development');
+  process.exit(1);
+}
+
+let output = '';
+
+if (child.stdout) {
+  child.stdout.on('data', (chunk) => {
+    const text = String(chunk);
+    output += text;
+    process.stdout.write(text);
+  });
+}
+
+if (child.stderr) {
+  child.stderr.on('data', (chunk) => {
+    const text = String(chunk);
+    output += text;
+    process.stderr.write(text);
+  });
+}
+
+child.on('error', (error) => {
+  console.error('Failed to start the Squarespace local development server.');
+  console.error(error.message);
+  console.error('Docs: https://developers.squarespace.com/local-development');
+  process.exit(1);
+});
+
+child.on('close', (code) => {
+  if (
+    code !== 0 &&
+    /not recognized as an internal or external command|command not found/i.test(output)
+  ) {
+    console.error('Install the Squarespace local development server first, then rerun this command.');
+    console.error('Docs: https://developers.squarespace.com/local-development');
+  }
+
+  process.exit(code === null ? 1 : code);
+});

--- a/site.region
+++ b/site.region
@@ -25,7 +25,7 @@
 
       <!-- cms content injection point -->
       <main class="content-container" role="main" data-content-field="main-content">
-       {squarespace.main-content}
+        {squarespace.main-content}
       </main>
 
       <!--Footer with open block field -->
@@ -34,6 +34,8 @@
       </footer>
 
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/animejs/dist/bundles/anime.umd.min.js"></script>
 
     <!-- combo and minify scripts when not logged in -->
     <squarespace:script src="site.js" combo="{.if authenticatedAccount}false{.or}true{.end}" />

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,117 +1,532 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Shrikhand&family=Special+Elite&display=swap');
 
 /* CSS pre-processing by {less}. http://lesscss.org/
 ***************************************************/
 
+.typewriter-label(@size: 0.78rem, @spacing: 0.08em) {
+  font-family: 'Special Elite', 'Courier New', monospace;
+  font-size: @size;
+  line-height: 1.8;
+  letter-spacing: @spacing;
+  text-transform: uppercase;
+}
 
+.paper-panel(@radius: 24px, @border-alpha: 0.08) {
+  border: 1px solid rgba(39, 24, 31, @border-alpha);
+  border-radius: @radius;
+}
 
-/* General syles
-***************************************************/
+.pill-action() {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.7rem 1rem 0.55rem;
+  .typewriter-label(0.78rem, 0.12em);
+  color: var(--ink);
+  text-decoration: none;
+  background: rgba(255, 247, 241, 0.74);
+  border: 1px solid rgba(39, 24, 31, 0.16);
+  border-radius: 999px;
+}
+
+.pill-action-hover() {
+  color: var(--paper);
+  background: var(--cobalt);
+}
+
+:root {
+  --ink: #27181f;
+  --ink-soft: rgba(39, 24, 31, 0.74);
+  --paper: #fff7f1;
+  --cobalt: #2450b5;
+  --lipstick: #c83d4b;
+  --shadow: 0 24px 70px rgba(81, 31, 52, 0.14);
+}
+
+html {
+  background:
+    radial-gradient(circle at top left, rgba(245, 207, 97, 0.4), transparent 32%),
+    radial-gradient(circle at top right, rgba(183, 215, 238, 0.45), transparent 24%),
+    linear-gradient(135deg, #f8d0d3 0%, #fff6ee 44%, #f4e8dd 100%);
+}
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont,
-    "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
-    "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
-  font-size: 100%;
-  font-weight: normal;
+  margin: 0;
+  color: var(--ink);
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 24px;
+  line-height: 1.65;
+  letter-spacing: 0.01em;
+  background:
+    linear-gradient(90deg, rgba(39, 24, 31, 0.08) 0, rgba(39, 24, 31, 0.08) 1px, transparent 1px, transparent 100%),
+    linear-gradient(180deg, rgba(39, 24, 31, 0.03), rgba(39, 24, 31, 0.03));
+  background-size: 100% 100%, 22px 22px;
+}
+
+body:before,
+body:after {
+  content: '';
+  position: fixed;
+  z-index: 0;
+  border-radius: 999px;
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+body:before {
+  top: 8vh;
+  right: -8vw;
+  width: 30vw;
+  height: 30vw;
+  background: rgba(200, 61, 75, 0.16);
+}
+
+body:after {
+  bottom: -10vw;
+  left: -6vw;
+  width: 34vw;
+  height: 34vw;
+  background: rgba(36, 80, 181, 0.12);
+}
+
+img {
+  display: block;
+  max-width: 100%;
 }
 
 .site-container {
-  line-height: 1.6em;
-  color: #777;
-  max-width: 1020px;
-  padding: 6vw;
+  position: relative;
+  z-index: 1;
+  width: min(1180px, calc(100% - 48px));
+  margin: 24px auto;
+  padding: clamp(28px, 4vw, 48px);
+  color: var(--ink);
+  background:
+    linear-gradient(180deg, rgba(255, 247, 241, 0.95), rgba(246, 235, 226, 0.98)),
+    var(--paper);
+  .paper-panel(36px);
+  box-shadow: var(--shadow);
 
-  h1, h2, h3 {
-    font-weight: normal;
-    line-height: 1.2em;
+  h1,
+  h2,
+  h3,
+  h4 {
+    margin: 0 0 0.45em;
+    color: var(--ink);
+    font-family: 'Shrikhand', 'Times New Roman', serif;
+    font-weight: 400;
+    line-height: 0.98;
+    letter-spacing: 0.02em;
+  }
+
+  h1 {
+    font-size: clamp(3rem, 7vw, 6.2rem);
+  }
+
+  h2 {
+    font-size: clamp(2.2rem, 4vw, 4rem);
+  }
+
+  h3 {
+    font-size: clamp(1.65rem, 3vw, 2.4rem);
+  }
+
+  p {
+    margin: 0 0 1em;
   }
 
   a {
-    color: cornflowerblue;
+    color: var(--cobalt);
+    text-decoration-color: rgba(36, 80, 181, 0.3);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.15em;
+    transition: color 180ms ease, text-decoration-color 180ms ease, transform 180ms ease;
+
+    &:hover,
+    &:focus {
+      color: var(--paper);
+      text-decoration-color: rgba(255, 247, 241, 0.45);
+      background: var(--cobalt);
+      transform: translateY(-1px);
+    }
 
     &.disabled {
-      color: #ccc;
+      color: rgba(39, 24, 31, 0.35);
     }
+  }
+
+  blockquote {
+    margin: 1.6em 0;
+    padding: 1.1em 1.2em;
+    font-size: 1.2em;
+    font-style: italic;
+    color: var(--ink);
+    background: rgba(246, 199, 203, 0.4);
+    border-left: 5px solid var(--lipstick);
+    border-radius: 18px;
   }
 }
 
 .site-header {
-  margin-bottom: 4vw;
+  position: relative;
+  display: grid;
+  gap: 28px;
+  margin-bottom: clamp(40px, 6vw, 72px);
+  padding: clamp(24px, 4vw, 40px);
+  background:
+    linear-gradient(120deg, rgba(245, 207, 97, 0.5), rgba(246, 199, 203, 0.7) 50%, rgba(183, 215, 238, 0.56));
+  .paper-panel(30px);
+  overflow: hidden;
 }
 
-.site-navigation { }
+.site-header:before {
+  content: 'Paris Notes / Collection Edit';
+  .typewriter-label(0.72rem, 0.26em);
+  color: rgba(39, 24, 31, 0.7);
+}
+
+.site-header:after {
+  content: '';
+  position: absolute;
+  right: -40px;
+  bottom: -40px;
+  width: 180px;
+  height: 180px;
+  background:
+    radial-gradient(circle, rgba(255, 247, 241, 0.8) 0, rgba(255, 247, 241, 0.78) 30%, transparent 31%),
+    radial-gradient(circle at center, transparent 52%, rgba(39, 24, 31, 0.16) 53%, rgba(39, 24, 31, 0.16) 55%, transparent 56%);
+  transform: rotate(-12deg);
+}
+
+.site-navigation {
+  order: 2;
+}
 
 .site-navigation-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 0;
   padding: 0;
+  list-style: none;
+}
+
+.site-sub-navigation-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.site-navigation-item,
+.site-sub-navigation-item {
+  display: inline-flex;
+  flex-wrap: wrap;
+  margin: 0;
 }
 
 .site-navigation-item {
-  display: inline-block;
-  font-size: 87.5%;
+  .typewriter-label(0.78rem, 0.15em);
+}
 
-  & + .site-navigation-item {
-    margin-left: 1em;
-  }
+.site-sub-navigation-item {
+  .typewriter-label(0.78rem, 0.15em);
+}
 
-  a {
-    color: #111;
-    text-decoration: none;
+.site-navigation-item > a,
+.site-sub-navigation-item > a {
+  .pill-action();
+  color: var(--ink);
+  background: rgba(255, 247, 241, 0.7);
+  border: 1px solid rgba(39, 24, 31, 0.12);
+  box-shadow: 0 8px 18px rgba(39, 24, 31, 0.08);
+}
 
-    &:hover {
-      color: #999;
-    }
-  }
+.site-navigation-item > a:hover,
+.site-navigation-item > a:focus,
+.site-sub-navigation-item > a:hover,
+.site-sub-navigation-item > a:focus {
+  .pill-action-hover();
+  transform: translateY(-1px);
+}
 
-  &.active-link > a {
-    color: #999;
-  }
-
+.site-navigation-item.active-link > a,
+.site-sub-navigation-item.active-link > a {
+  color: var(--paper);
+  background: var(--lipstick);
 }
 
 .site-title-heading {
-
-  .site-title-link {
-    color: #111;
-    font-weight: 400;
-    text-decoration: none;
-  }
+  max-width: 11ch;
+  margin: 0;
 }
 
-.content-container { }
+.site-title-link {
+  color: var(--ink);
+  text-decoration: none;
+  text-shadow: 3px 3px 0 rgba(255, 247, 241, 0.72);
+}
+
+.content-container {
+  position: relative;
+}
+
+.content-container:before {
+  content: 'Catalogue / Journal';
+  display: inline-block;
+  margin-bottom: 18px;
+  padding: 0.45rem 0.65rem 0.35rem;
+  .typewriter-label(0.78rem, 0.14em);
+  color: var(--paper);
+  background: var(--ink);
+  border-radius: 4px;
+}
 
 .site-footer {
-  font-size: 75%;
-  margin-top: 4vw;
-  margin-bottom: 4vw;
+  margin-top: clamp(40px, 6vw, 72px);
+  padding: 22px 26px;
+  .typewriter-label(0.74rem);
+  color: var(--ink-soft);
+  background: rgba(255, 247, 241, 0.78);
+  .paper-panel();
 }
 
+body.homepage .content-container {
+  padding: clamp(28px, 4vw, 44px);
+  background:
+    linear-gradient(135deg, rgba(202, 219, 99, 0.36), rgba(255, 247, 241, 0.74) 45%, rgba(183, 215, 238, 0.45));
+  border-radius: 28px;
+}
 
+.main-image {
+  display: block;
+  margin-bottom: 1.5rem;
+  overflow: hidden;
+  border-radius: 24px;
+  background: var(--paper);
+  box-shadow: 0 18px 35px rgba(39, 24, 31, 0.12);
+}
 
-/* Homepage
-***************************************************/
+.main-image img {
+  width: 100%;
+  height: auto;
+}
 
-body.homepage { }
+.title {
+  margin-bottom: 0.35em;
+}
 
+.title a {
+  color: inherit;
+  text-decoration: none;
+}
 
+.title a:hover,
+.title a:focus {
+  color: var(--lipstick);
+}
 
-/* Blog list
-***************************************************/
+.meta,
+.filtered-by,
+.post-taxonomy,
+.post-actions {
+  .typewriter-label();
+}
+
+.meta,
+.filtered-by {
+  color: var(--ink-soft);
+}
+
+.filtered-by {
+  display: inline-block;
+  margin: 0 0 26px;
+  padding: 0.6rem 0.8rem 0.45rem;
+  background: rgba(245, 207, 97, 0.36);
+  border-radius: 12px;
+}
+
+.excerpt,
+.post-body {
+  font-size: 1.08em;
+}
+
+.link,
+.blog-list-pagination a,
+.blog-item-pagination a,
+.category,
+.tag,
+.sqs-block-button-element,
+input[type="submit"],
+button {
+  .pill-action();
+}
+
+.link:hover,
+.link:focus,
+.blog-list-pagination a:hover,
+.blog-item-pagination a:hover,
+.category:hover,
+.tag:hover,
+.sqs-block-button-element:hover,
+input[type="submit"]:hover,
+button:hover {
+  .pill-action-hover();
+}
 
 body.collection-type-blog.view-list {
+  .content-container {
+    display: grid;
+    gap: 28px;
+  }
 
-  .blog-list-item + .blog-list-item {
-    margin-top: 3vw;
+  .blog-list-item {
+    position: relative;
+    display: grid;
+    gap: 18px;
+    padding: clamp(24px, 4vw, 38px);
+    .paper-panel(30px, 0.09);
+    box-shadow: 0 20px 50px rgba(39, 24, 31, 0.08);
+    overflow: hidden;
+
+    &:before {
+      content: '';
+      position: absolute;
+      inset: auto auto 0 0;
+      width: 140px;
+      height: 140px;
+      border-radius: 0 100% 0 0;
+      opacity: 0.72;
+    }
+
+    .title {
+      max-width: 10ch;
+    }
+
+    .main-image img {
+      aspect-ratio: 4 / 3;
+      object-fit: cover;
+    }
+
+    & + .blog-list-item {
+      margin-top: 0;
+    }
+  }
+
+  .blog-list-item:nth-child(3n + 1) {
+    background: linear-gradient(135deg, rgba(246, 199, 203, 0.64), rgba(255, 247, 241, 0.96));
+
+    &:before {
+      background: rgba(36, 80, 181, 0.2);
+    }
+  }
+
+  .blog-list-item:nth-child(3n + 2) {
+    background: linear-gradient(135deg, rgba(245, 207, 97, 0.54), rgba(255, 247, 241, 0.96));
+
+    &:before {
+      background: rgba(200, 61, 75, 0.22);
+    }
+  }
+
+  .blog-list-item:nth-child(3n) {
+    background: linear-gradient(135deg, rgba(183, 215, 238, 0.62), rgba(255, 247, 241, 0.96));
+
+    &:before {
+      background: rgba(202, 219, 99, 0.32);
+    }
   }
 }
 
+body.collection-type-blog.view-item {
+  .content-container {
+    padding: clamp(28px, 5vw, 54px);
+    background:
+      linear-gradient(135deg, rgba(255, 247, 241, 0.95), rgba(246, 199, 203, 0.34)),
+      var(--paper);
+    .paper-panel(30px);
+    box-shadow: 0 18px 46px rgba(39, 24, 31, 0.08);
+  }
 
+  article {
+    display: grid;
+    gap: 18px;
+  }
 
-/* Break grid and stack blocks on small screens
-***************************************************/
-
-@media screen and (max-width: 640px) {
-  @import 'sqs-grid-breaker';
+  .post-taxonomy,
+  .post-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
 }
 
+.blog-list-pagination,
+.blog-item-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: space-between;
+  margin-top: 10px;
+}
 
+.category,
+.tag {
+  margin-right: 6px;
+}
+
+.sqs-block {
+  position: relative;
+}
+
+.sqs-block-image .image-block-outer-wrapper,
+.sqs-block-horizontalrule hr {
+  border-radius: 24px;
+}
+
+.sqs-block-horizontalrule hr {
+  height: 1px;
+  border: 0;
+  background: linear-gradient(90deg, transparent, rgba(39, 24, 31, 0.28), transparent);
+}
+
+@media screen and (max-width: 900px) {
+  body {
+    font-size: 21px;
+  }
+
+  .site-container {
+    width: min(100% - 24px, 1180px);
+    padding: 18px;
+    border-radius: 28px;
+  }
+
+  .site-header,
+  body.collection-type-blog.view-item .content-container {
+    border-radius: 24px;
+  }
+}
+
+@media screen and (max-width: 640px) {
+  body {
+    font-size: 19px;
+  }
+
+  .site-header {
+    gap: 20px;
+  }
+
+  .site-title-heading {
+    max-width: none;
+  }
+
+  .blog-list-pagination,
+  .blog-item-pagination {
+    justify-content: flex-start;
+  }
+
+  @import 'sqs-grid-breaker';
+}


### PR DESCRIPTION
- Introduced `index.html` and `post.html` for local preview of the Simply Taylor template.
- Updated `readme.md` with instructions for local preview and Squarespace local development.
- Created `doctor.js` to check local environment prerequisites.
- Added `load-env.js` for loading environment variables from `.env` files.
- Implemented `preview.js` to serve local preview and compile styles.
- Enhanced `site.js` with animations for blog items and buttons.
- Added `squarespace-dev.js` to facilitate running the Squarespace local development server.
- Updated `site.region` for script inclusion and content injection.
- Expanded `base.less` with new styles and responsive design adjustments.